### PR TITLE
Multival source links

### DIFF
--- a/_includes/js/item-js.html
+++ b/_includes/js/item-js.html
@@ -105,13 +105,18 @@
 
                     let valueElAsStr = `${value}`;
                     if (field.external_link) {
-                        valueElAsStr = value
-                            .split(';')
-                            .map((link) => ( `<a href=${link} target="_blank" rel="noopener">${link}</a>&nbsp;` ))
-                            .join('');
+                        valueElAsStr = 
+                            '<ul class="external-link-list">' +
+                            value
+                                .split(';')
+                                .map((link) => (
+                                    `<li><a href=${link} target="_blank" rel="noopener">${link}</a></li>`
+                                ))
+                                .join('') +
+                            '</ul>'
                     }
 
-                    fields += `<dt class="field">{{ f.display_name }}:</dt>&nbsp;<dd class="field-value">${valueElAsStr}</dd>`;
+                    fields += `<dt class="field">{{ f.display_name }}:</dt><dd class="field-value">${valueElAsStr}</dd>`;
                 }
             {% endif %}{% endfor %}
             fields += '</dl>';

--- a/_includes/js/item-js.html
+++ b/_includes/js/item-js.html
@@ -99,7 +99,20 @@
                 fields += '<dt class="field">{{ f.display_name }}:</dt> <dd class="field-value">' + browseLinks + '</dd>';
             }
             {%- else -%}
-            if (item[{{ f.field | jsonify }}]) { fields += '<dt class="field">{{ f.display_name }}:</dt> <dd class="field-value">{% if f.external_link == "true" %}<a href="' + item[{{ f.field | jsonify }}] + '" target="_blank" rel="noopener">' + item[{{ f.field | jsonify }}] + '</a>{% else %}' + item[{{ f.field | jsonify }}] + '{% endif %}</dd>'; }
+                if (item[{{ f.field | jsonify }}]) {
+                    const field = {{ f | jsonify }};
+                    const value = item[field.field];
+
+                    let valueElAsStr = `${value}`;
+                    if (field.external_link) {
+                        valueElAsStr = value
+                            .split(';')
+                            .map((link) => ( `<a href=${link} target="_blank" rel="noopener">${link}</a>&nbsp;` ))
+                            .join('');
+                    }
+
+                    fields += `<dt class="field">{{ f.display_name }}:</dt>&nbsp;<dd class="field-value">${valueElAsStr}</dd>`;
+                }
             {% endif %}{% endfor %}
             fields += '</dl>';
             return fields;

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -2,3 +2,11 @@
     Put your custom SCSS here! 
     This allows you to override any CollectionBuilder or Bootstrap CSS without modifying the base theme files directly.
 */
+.external-link-list {
+    list-style: none;
+}
+
+dt.field {
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+}


### PR DESCRIPTION
![image](https://github.com/lxcprojects/samplecontainer/assets/5167587/215b50cb-d77e-4e11-98fb-fd977e55ff3d)

Allow any field on the item page marked as "external_link" (in the `config-metadata.csv` file) to contain multiple values, separated by semicolon (`;`). The values are separated and rendered into a list on the item page. A bit of CSS hides the bullet points and adjusts some spacing. Output HTML:

``` html
<dd class="field-value">
  <ul class="external-link-list">
    <li>
      <a href="https://lxcprojects.github.io/keywords/keywords/d0072.html" target="_blank" rel="noopener">https://lxcprojects.github.io/keywords/keywords/d0072.html</a>
    </li>
    <li>
      <a href="https://lxcprojects.github.io/keywords/keywords/d0073.html" target="_blank" rel="noopener"> https://lxcprojects.github.io/keywords/keywords/d0073.html</a>
    </li>
    <li>
      <a href="https://lxcprojects.github.io/keywords/keywords/d0074.html" target="_blank" rel="noopener"> https://lxcprojects.github.io/keywords/keywords/d0074.html</a>
    </li>
  </ul>
</dd>
```

If we want to limit our changes to these base layouts & templates, I can back out of this change and submit a new PR (which is pretty much ready to go)