### PR TITLE
Remove item format filter button from browse

### DIFF
--- a/_data/config-browse.csv
+++ b/_data/config-browse.csv
@@ -1,5 +1,6 @@
 field,display_name,btn,hidden,sort_name
 date,Date,,,Date
 creator,Creator,,,
-subject,,true
-location,,true
+subject,,true,,
+location,,true,,
+format,,,true,

--- a/_includes/js/browse-js.html
+++ b/_includes/js/browse-js.html
@@ -12,17 +12,7 @@
 /* add items */
 var items = [
     {% for i in items %}
-    {
-        "title":{{ i.title | strip | jsonify }},
-        "format":{% if i.format %}{{ i.format | jsonify }}{% else %}""{% endif %},
-        {% for f in fields %}{% if i[f.field] %}{{ f.field | jsonify }}:{{ i[f.field] | strip | jsonify }},{% endif %}{% endfor %}
-        {% if i.youtubeid %} "youtube": {{ i.youtubeid | jsonify }}, {% endif %}
-        {% if  i.filename contains '/' %}"filename": "{{ i.filename }}" {% else %}"filename":"{{ '/objects/' | relative_url | append: i.filename }}"{% endif %}, 
-        "link": "{% if i.parentid %}{{ i.parentid }}#{{ i.objectid }}{% else %}{{ i.objectid }}{% endif %}", 
-        "id":{{ i.objectid | jsonify }}
-    }
-        {% unless forloop.last %},{% endunless %}
-    {% endfor %}
+    { "title":{{ i.title | strip | jsonify }}, "format":{% if i.format %}{{ i.format | jsonify }}{% else %}""{% endif %}, {% for f in fields %}{% if i[f.field] %}{{ f.field | jsonify }}:{{ i[f.field] | strip | jsonify }},{% endif %}{% endfor %} {% if i.youtubeid %} "youtube": {{ i.youtubeid | jsonify }}, {% endif %}{% if  i.filename contains '/' %}"filename": "{{ i.filename }}" {% else %}"filename":"{{ '/objects/' | relative_url | append: i.filename }}"{% endif %}, "link": "{% if i.parentid %}{{ i.parentid }}#{{ i.objectid }}{% else %}{{ i.objectid }}{% endif %}", "id":{{ i.objectid | jsonify }} }{% unless forloop.last %},{% endunless %}{% endfor %}
 ];
 
 /* function to create cards for each item */ 

--- a/_includes/js/browse-js.html
+++ b/_includes/js/browse-js.html
@@ -12,7 +12,17 @@
 /* add items */
 var items = [
     {% for i in items %}
-    { "title":{{ i.title | strip | jsonify }}, "format":{% if i.format %}{{ i.format | jsonify }}{% else %}""{% endif %}, {% for f in fields %}{% if i[f.field] %}{{ f.field | jsonify }}:{{ i[f.field] | strip | jsonify }},{% endif %}{% endfor %} {% if i.youtubeid %} "youtube": {{ i.youtubeid | jsonify }}, {% endif %}{% if  i.filename contains '/' %}"filename": "{{ i.filename }}" {% else %}"filename":"{{ '/objects/' | relative_url | append: i.filename }}"{% endif %}, "link": "{% if i.parentid %}{{ i.parentid }}#{{ i.objectid }}{% else %}{{ i.objectid }}{% endif %}", "id":{{ i.objectid | jsonify }} }{% unless forloop.last %},{% endunless %}{% endfor %}
+    {
+        "title":{{ i.title | strip | jsonify }},
+        "format":{% if i.format %}{{ i.format | jsonify }}{% else %}""{% endif %},
+        {% for f in fields %}{% if i[f.field] %}{{ f.field | jsonify }}:{{ i[f.field] | strip | jsonify }},{% endif %}{% endfor %}
+        {% if i.youtubeid %} "youtube": {{ i.youtubeid | jsonify }}, {% endif %}
+        {% if  i.filename contains '/' %}"filename": "{{ i.filename }}" {% else %}"filename":"{{ '/objects/' | relative_url | append: i.filename }}"{% endif %}, 
+        "link": "{% if i.parentid %}{{ i.parentid }}#{{ i.objectid }}{% else %}{{ i.objectid }}{% endif %}", 
+        "id":{{ i.objectid | jsonify }}
+    }
+        {% unless forloop.last %},{% endunless %}
+    {% endfor %}
 ];
 
 /* function to create cards for each item */ 
@@ -73,7 +83,8 @@ function makeCard(obj) {
     {% endunless %}{% endfor %}
     card += '</p>';
     // media type
-    if(obj.format != "") {
+    const formatField = {{ fields | jsonify}}.find(f => f.field == 'format') || {};
+    if(!formatField.hidden && obj.format != "") {
         card += '<p class="card-text"><small><a class="btn btn-sm btn-outline-secondary" href="{{ '/browse.html' | relative_url }}#' + encodeURIComponent(obj.format) + '">' + 
         obj.format.split("/").pop().replace("_", " ").toUpperCase() + ' <svg class="bi icon-sprite"><use xlink:href="{{ "/assets/lib/cb-icons.svg" | relative_url }}#';
         if(obj.format.includes('image')){


### PR DESCRIPTION
Fixes https://github.com/lxcprojects/samplecontainer/issues/5

Add a sort of ham-fisted configuration option to hide the "format" button. The original intent of this button is to filter the browse to the selected format. In our case, since all items are set to the same format, it is redundant so we would like to be able to hide this button. IMO this mostly sticks to the intent of this config file and still keeps it simple to turn this button on or off

Screenshot w/no file format button, running locally:
![image](https://github.com/lxcprojects/samplecontainer/assets/5167587/4484cc1e-1fef-4ed6-8fdc-0193b2b7d995)
